### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To check ios set up `appium-doctor --ios`
 1) Open command prompt, go to `<sdk emulator path>`
 
 ```
-Command to stard AVD: `emulator -avd <avd_name>`
+Command to start AVD: `emulator -avd <avd_name>`
 Command to stop/kill AVD: `adb -e emu kill`
 ```
 


### PR DESCRIPTION
## Summary
- fix a small typo in README for starting Android emulator

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851ff2a0cbc8328be0ce1392efb34d4