### PR TITLE
Fix variable types in driver and screen recording utils

### DIFF
--- a/src/main/java/com/automate/driver/Drivers.java
+++ b/src/main/java/com/automate/driver/Drivers.java
@@ -27,7 +27,7 @@ public final class Drivers {
 
   public static AppiumDriver<MobileElement> createAndroidDriverForNativeApp(String deviceName, String udid, int port, String emulator) {
     try {
-      var capability = new DesiredCapabilities();
+      DesiredCapabilities capability = new DesiredCapabilities();
       capability.setCapability(CapabilityType.PLATFORM_NAME, Platform.ANDROID);
       capability.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
       capability.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.ANDROID_UIAUTOMATOR2); // Specific to Android
@@ -50,7 +50,7 @@ public final class Drivers {
 
   public static AppiumDriver<MobileElement> createAndroidDriverForWeb(String deviceName, String udid, int port, String emulator) {
     try {
-      var capability = new DesiredCapabilities();
+      DesiredCapabilities capability = new DesiredCapabilities();
       capability.setCapability(CapabilityType.PLATFORM_NAME, Platform.ANDROID);
       capability.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
       capability.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.ANDROID_UIAUTOMATOR2);
@@ -72,7 +72,7 @@ public final class Drivers {
 
   public static AppiumDriver<MobileElement> createIOSDriverForNativeApp(String deviceName, String udid, int port) {
     try {
-      var capability = new DesiredCapabilities();
+      DesiredCapabilities capability = new DesiredCapabilities();
       capability.setCapability(CapabilityType.PLATFORM_NAME, Platform.IOS);
       capability.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
       capability.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.IOS_XCUI_TEST);
@@ -90,7 +90,7 @@ public final class Drivers {
 
   public static AppiumDriver<MobileElement> createIOSDriverForWeb(String deviceName, String udid, int port) {
     try {
-      var capability = new DesiredCapabilities();
+      DesiredCapabilities capability = new DesiredCapabilities();
       capability.setCapability(CapabilityType.PLATFORM_NAME, Platform.IOS);
       capability.setCapability(MobileCapabilityType.DEVICE_NAME, deviceName);
       capability.setCapability(MobileCapabilityType.AUTOMATION_NAME, AutomationName.IOS_XCUI_TEST);

--- a/src/main/java/com/automate/utils/screenrecording/ScreenRecordingUtils.java
+++ b/src/main/java/com/automate/utils/screenrecording/ScreenRecordingUtils.java
@@ -19,8 +19,8 @@ public final class ScreenRecordingUtils {
   }
 
   public static void stopScreenRecording(String methodName) {
-    var recordedVideoFile = ((CanRecordScreen) DriverManager.getDriver()).stopRecordingScreen();
-    var pathToWriteVideoFile = FrameworkConstants.getScreenRecordingsPath() + File.separator + methodName + ".mp4";
+    String recordedVideoFile = ((CanRecordScreen) DriverManager.getDriver()).stopRecordingScreen();
+    String pathToWriteVideoFile = FrameworkConstants.getScreenRecordingsPath() + File.separator + methodName + ".mp4";
     writeToOutputStream(pathToWriteVideoFile, recordedVideoFile);
   }
 


### PR DESCRIPTION
## Summary
- use `DesiredCapabilities` instead of `var` when configuring drivers
- use explicit `String` variables when storing screen recording info

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851fd8034088328870df6beffb4857e