### PR TITLE
Fix WaitStrategy map and log typo

### DIFF
--- a/src/main/java/com/automate/factories/WaitFactory.java
+++ b/src/main/java/com/automate/factories/WaitFactory.java
@@ -23,13 +23,16 @@ import static com.automate.enums.WaitStrategy.VISIBLE;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class WaitFactory {
 
-  private static final Map<WaitStrategy, Function<MobileElement, WebElement>> WAIT_FOR_ELEMENT_FUNCTION_MAP =
-    new EnumMap<>(WaitStrategy.class);
+    private static final Map<WaitStrategy, Function<MobileElement, WebElement>> WAIT_FOR_ELEMENT_FUNCTION_MAP =
+      new EnumMap<>(WaitStrategy.class);
 
   private static final Function<MobileElement, WebElement> CLICKABLE_ELEMENT = mobileElement ->
     new WebDriverWait(DriverManager.getDriver(), FrameworkConstants.EXPLICIT_WAIT)
       .until(ExpectedConditions.elementToBeClickable(mobileElement));
   private static final Function<MobileElement, WebElement> VISIBILITY_OF_ELEMENT = mobileElement ->
+    new WebDriverWait(DriverManager.getDriver(), FrameworkConstants.EXPLICIT_WAIT)
+      .until(ExpectedConditions.visibilityOf(mobileElement));
+  private static final Function<MobileElement, WebElement> PRESENCE_OF_ELEMENT = mobileElement ->
     new WebDriverWait(DriverManager.getDriver(), FrameworkConstants.EXPLICIT_WAIT)
       .until(ExpectedConditions.visibilityOf(mobileElement));
   private static final Function<MobileElement, WebElement> NO_MATCH = mobileElement -> mobileElement;
@@ -51,6 +54,7 @@ public final class WaitFactory {
   static {
     WAIT_FOR_ELEMENT_FUNCTION_MAP.put(CLICKABLE, CLICKABLE_ELEMENT);
     WAIT_FOR_ELEMENT_FUNCTION_MAP.put(VISIBLE, VISIBILITY_OF_ELEMENT);
+    WAIT_FOR_ELEMENT_FUNCTION_MAP.put(PRESENCE, PRESENCE_OF_ELEMENT);
     WAIT_FOR_ELEMENT_FUNCTION_MAP.put(NONE, NO_MATCH);
     WAIT_FOR_ELEMENT_LOCATED_BY_FUNCTION_MAP.put(CLICKABLE, CLICKABLE_ELEMENT_BY);
     WAIT_FOR_ELEMENT_LOCATED_BY_FUNCTION_MAP.put(PRESENCE, PRESENCE_OF_ELEMENT_BY);

--- a/src/main/java/com/automate/pages/screen/ScreenActions.java
+++ b/src/main/java/com/automate/pages/screen/ScreenActions.java
@@ -243,7 +243,7 @@ public class ScreenActions {
         ((AndroidDriver<MobileElement>) DriverManager.getDriver()).setPowerAC(PowerACState.OFF);
         break;
       default:
-        ExtentReportLogger.warning("Voice state not available");
+        ExtentReportLogger.warning("Power state not available");
         break;
     }
   }


### PR DESCRIPTION
## Summary
- map PRESENCE wait strategy to avoid NullPointerExceptions
- fix typo in power state warning message

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851fcadb2cc83289879821b600ce425