### PR TITLE
Fix deleteFolder cleanup

### DIFF
--- a/src/main/java/com/automate/utils/TestUtils.java
+++ b/src/main/java/com/automate/utils/TestUtils.java
@@ -26,7 +26,7 @@ public final class TestUtils {
   public static void deleteFolder(File file) {
     File[] files = file.listFiles();
     if (Objects.nonNull(files))
-      Arrays.asList(files).forEach(content -> file.delete());
+      Arrays.asList(files).forEach(content -> content.delete());
   }
 
   public static HashMap<String, String> parseStringXML(InputStream in) throws IOException, SAXException, ParserConfigurationException {


### PR DESCRIPTION
## Summary
- ensure deleteFolder removes files

## Testing
- `mvn -q -DskipTests verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68520086cf888328b5ce873c1d8d5bed