### PR TITLE
Fix Javadoc for tapByElement

### DIFF
--- a/src/main/java/com/automate/pages/screen/ScreenActions.java
+++ b/src/main/java/com/automate/pages/screen/ScreenActions.java
@@ -366,7 +366,7 @@ public class ScreenActions {
   }
 
   /**
-   * tap to element for 250sec
+   * tap to element for 250 ms
    *
    * @param androidElement element
    */


### PR DESCRIPTION
## Summary
- correct comment for `tapByElement`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68520087e46883289f034d4f397ca851