### PR TITLE
Add login page display assertion

### DIFF
--- a/src/test/java/com/tests/LoginTest.java
+++ b/src/test/java/com/tests/LoginTest.java
@@ -20,6 +20,7 @@ public final class LoginTest extends BaseTest {
   @BeforeMethod
   public void initialize() {
     loginPage = new LoginPage();
+    Assert.assertTrue(loginPage.isLoginPageDisplayed(), "Login page should be displayed");
   }
 
   @FrameworkAnnotation(author = "User-1", category = {CategoryType.REGRESSION, CategoryType.SMOKE})


### PR DESCRIPTION
## Summary
- validate login page is displayed on initialization

## Testing
- `mvn -q -DskipTests verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852008b21488328b42ca511513eb81f