### PR TITLE
Fix stopAppiumServer null and running check

### DIFF
--- a/src/main/java/com/automate/utils/AppiumServerManager.java
+++ b/src/main/java/com/automate/utils/AppiumServerManager.java
@@ -52,13 +52,15 @@ public final class AppiumServerManager {
 
   public static void stopAppiumServer() {
     if (PropertyUtils.getPropertyValue(ConfigProperties.START_APPIUM_SERVER).equalsIgnoreCase("yes")) {
-      service.stop();
-      Runtime runtime = Runtime.getRuntime();
-      try {
-        runtime.exec("taskkill /F /IM node.exe");
-        runtime.exec("taskkill /F /IM cmd.exe");
-      } catch (Exception e) {
-        e.printStackTrace();
+      if (service != null && service.isRunning()) {
+        service.stop();
+        Runtime runtime = Runtime.getRuntime();
+        try {
+          runtime.exec("taskkill /F /IM node.exe");
+          runtime.exec("taskkill /F /IM cmd.exe");
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- protect AppiumServerManager.stopAppiumServer when service wasn't started

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68520694a7f483289723c2f56912ab07